### PR TITLE
feat: disable reporter by using env var

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,14 @@ const { setConfig } = require('./config');
 const { log, debugLog } = require('./logger');
 const generateReport = require('./generateReport');
 
+const IS_DISABLED = process.env['DISABLE_CYPRESS_MOCHAWESOME_REPORTER'] === 'true';
+
 async function beforeRunHook({ config }) {
+  if (IS_DISABLED) {
+    log('DISABLE_CYPRESS_MOCHAWESOME_REPORTER is true, ignore before run hook');
+    return;
+  }
+
   const { outputDir, jsonDir, reporterOptions } = await setConfig(config);
 
   // Only if overwrite is set to false delete only .jsons folder and keep the html files
@@ -20,6 +27,11 @@ async function beforeRunHook({ config }) {
 }
 
 async function afterRunHook() {
+  if (IS_DISABLED) {
+    log('DISABLE_CYPRESS_MOCHAWESOME_REPORTER is true, ignore after run hook');
+    return;
+  }
+
   await generateReport();
 
   debugLog('done');


### PR DESCRIPTION
related: #68

To disable this reporter when this reporter is the active reporter, set env var called `DISABLE_CYPRESS_MOCHAWESOME_REPORTER` with the value `true`

```
DISABLE_CYPRESS_MOCHAWESOME_REPORTER=true cypress run
```