### PR TITLE
feat: allow the usage of javascript configFile in mocha reporter options

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -31,13 +31,26 @@ function getConfig() {
 
 module.exports = { setConfig, getConfig };
 
+async function extractConfigFileOptions(configFile) {
+  const configFilePath = path.resolve(configFile);
+  const configFileExt = path.extname(configFile);
+
+  if(configFileExt === '.json') {
+    return await fse.readJson(configFilePath)
+  } else if (configFileExt === '.js') {
+    return require(configFilePath)
+  } else {
+    throw Error(`configFile ${configFile} cannot be resolved in reporterOptions. Supported extensions .json and .js`);
+  }
+}
+
 async function extractReporterOptions(options) {
   if (!options) {
     return undefined;
   }
 
   // If configFile property exist, read options from config file
-  const opts = options.configFile ? await fse.readJson(path.resolve(options.configFile)) : options;
+  const opts = options.configFile ? await extractConfigFileOptions(options.configFile) : options;
 
   // Only this reporter enabled
   if (!opts.reporterEnabled) {


### PR DESCRIPTION
When using the [cypress multi reporter libary](https://github.com/YOU54F/cypress-multi-reporters), it is possible to provide an external `configFile` that will contains the reporter options.

This configFile can be a `.json` file or a `.js` file.

This PR is adding the support for the `.js` file.