### PR TITLE
allow to define own filename for report

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ module.exports = defineConfig({
     embeddedScreenshots: true,
     inlineAssets: true,
     saveAllAttempts: false,
+    reportFileName: 'index.html',
   },
   e2e: {
     setupNodeEvents(on, config) {
@@ -112,12 +113,13 @@ module.exports = defineConfig({
 
 Additional reporter options:
 
-| name                  | type      | default | description                                                                                                        |
-| --------------------- | --------- | ------- | ------------------------------------------------------------------------------------------------------------------ |
-| `embeddedScreenshots` | `boolean` | `false` | Embedded external screenshots into HTML using base64, use with `inlineAssets` option to produce a single HTML file |
-| `quiet`               | `boolean` | `false` | Silence console messages                                                                                           |
-| `saveAllAttempts`     | `boolean` | `true`  | Save screenshots of all test attempts, set to `false` to save only the last attempt                                |
-| `debug`               | `boolean` | `false` | Creates log file with debug data                                                                                   |
+| name                  | type      | default      | description                                                                                                        |
+| --------------------- | --------- | ------------ | ------------------------------------------------------------------------------------------------------------------ |
+| `embeddedScreenshots` | `boolean` | `false`      | Embedded external screenshots into HTML using base64, use with `inlineAssets` option to produce a single HTML file |
+| `quiet`               | `boolean` | `false`      | Silence console messages                                                                                           |
+| `saveAllAttempts`     | `boolean` | `true`       | Save screenshots of all test attempts, set to `false` to save only the last attempt                                |
+| `debug`               | `boolean` | `false`      | Creates log file with debug data                                                                                   |
+| `reportFileName`      | `string`  | `index.html` | Defines report HTML file name for with test results                                                                |
 
 ## Examples
 

--- a/lib/generateReport.js
+++ b/lib/generateReport.js
@@ -22,8 +22,9 @@ async function mergeAndCreate(jsonDir, screenshotsDir, mochawesomeOptions) {
 
   log('Create HTML report');
 
+  const { reportFileName } = mochawesomeOptions;
   const html = await reportGenerator.create(report, {
-    reportFilename: 'index.html',
+    reportFilename: reportFileName || 'index.html',
     ...mochawesomeOptions,
   });
 


### PR DESCRIPTION
In some cases there is a need to save reports with unique name. Name of report file is also need to generate metadata with will describe report and indicate report file name. This change will allow to do it.