### PR TITLE
fix: unable to find jsons folder when cypress config is not in project root

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -15,6 +15,7 @@ async function setConfig(config) {
   setLoggerQuietMode(quiet === true);
   initDebugLog(debug === true);
 
+  debugLog(`cwd: ${process.cwd()}`);
   debugLog(`cypress.json: ${JSON.stringify(config)}`);
   debugLog(`simple config: ${JSON.stringify(_config)}`);
 
@@ -35,10 +36,10 @@ async function extractConfigFileOptions(configFile) {
   const configFilePath = path.resolve(configFile);
   const configFileExt = path.extname(configFile);
 
-  if(configFileExt === '.json') {
-    return await fse.readJson(configFilePath)
+  if (configFileExt === '.json') {
+    return await fse.readJson(configFilePath);
   } else if (configFileExt === '.js') {
-    return require(configFilePath)
+    return require(configFilePath);
   } else {
     throw Error(`configFile ${configFile} cannot be resolved in reporterOptions. Supported extensions .json and .js`);
   }
@@ -66,7 +67,7 @@ async function getSimpleCypressConfig(config) {
 
   const reporterOptions = (await extractReporterOptions(config.reporterOptions)) || {};
 
-  reporterOptions['reportDir'] = reporterOptions['reportDir'] || path.join(baseDir, consts.defaultHtmlOutputFolder);
+  reporterOptions['reportDir'] = path.join(baseDir, reporterOptions['reportDir'] || consts.defaultHtmlOutputFolder);
   const jsonDir = path.join(reporterOptions.reportDir, '/.jsons');
 
   return {


### PR DESCRIPTION
related: #95 