### PR TITLE
fix: reportDir absolute path

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -67,13 +67,18 @@ async function getSimpleCypressConfig(config) {
 
   const reporterOptions = (await extractReporterOptions(config.reporterOptions)) || {};
 
-  reporterOptions['reportDir'] = path.join(baseDir, reporterOptions['reportDir'] || consts.defaultHtmlOutputFolder);
+  reporterOptions.reportDir = reporterOptions.reportDir || consts.defaultHtmlOutputFolder;
+
+  if (!path.isAbsolute(reporterOptions.reportDir)) {
+    reporterOptions.reportDir = path.join(baseDir, reporterOptions.reportDir);
+  }
+
   const jsonDir = path.join(reporterOptions.reportDir, '/.jsons');
 
   return {
     jsonDir,
     reporterOptions,
     screenshotsDir: config.screenshotsFolder,
-    outputDir: reporterOptions['reportDir'],
+    outputDir: reporterOptions.reportDir,
   };
 }


### PR DESCRIPTION
resolves a bug created at #97

https://github.com/LironEr/cypress-mochawesome-reporter/pull/97#issuecomment-1212119873