### PR TITLE
Fixed videoOnFailOnly option applying to skipped tests

### DIFF
--- a/cypress/e2e/reportOutput.cy.js
+++ b/cypress/e2e/reportOutput.cy.js
@@ -18,10 +18,11 @@ describe('Report output', () => {
 
       it('Validate all tests exists', () => {
         cy.get('li[title="Suites"]').contains(4);
-        cy.get('li[title="Tests"]').contains(8);
+        cy.get('li[title="Tests"]').contains(9);
         cy.get('li[title="Passed"]').contains(2);
         cy.get('li[title="Failed"]').contains(4);
         cy.get('li[title="Skipped"]').contains(1);
+        cy.get('li[title="Pending"]').contains(1);
       });
 
       describe('Validate image exists', () => {
@@ -80,11 +81,17 @@ describe('Video output', () => {
           cy.validateTestHasVideo('todo exists')
           cy.validateTestHasVideo('add context to mochawesome report')
         })
+        it('video on skipped test', () => {
+          cy.validateTestHasVideo('skipped test')
+        })
       } else {
         it('no video on passed tests', () => {
           cy.validateTestHasNoVideo('default todos exists')
           cy.validateTestHasNoVideo('todo exists')
           cy.validateTestHasNoVideo('add context to mochawesome report')
+        })
+        it('no video on skipped tests', () => {
+          cy.validateTestHasNoVideo('skipped test')
         })
       }
     })

--- a/examples/mochawesome-flags/cypress/e2e/test2.cy.js
+++ b/examples/mochawesome-flags/cypress/e2e/test2.cy.js
@@ -12,4 +12,8 @@ describe('Test 2', () => {
       cy.addTestContext(`There were ${$liElements.length.toString()} items found in the todo-list`);
     });
   });
+  
+  it.skip('skipped test', () => {
+    cy.visit('site/index.html');
+  });
 });

--- a/examples/multiple-reporters-config-file/cypress/e2e/test2.cy.js
+++ b/examples/multiple-reporters-config-file/cypress/e2e/test2.cy.js
@@ -12,4 +12,8 @@ describe('Test 2', () => {
       cy.addTestContext(`There were ${$liElements.length.toString()} items found in the todo-list`);
     });
   });
+
+  it.skip('skipped test', () => {
+    cy.visit('site/index.html');
+  });
 });

--- a/examples/multiple-reporters/cypress/e2e/test2.cy.js
+++ b/examples/multiple-reporters/cypress/e2e/test2.cy.js
@@ -12,4 +12,8 @@ describe('Test 2', () => {
       cy.addTestContext(`There were ${$liElements.length.toString()} items found in the todo-list`);
     });
   });
+
+  it.skip('skipped test', () => {
+    cy.visit('site/index.html');
+  });
 });

--- a/examples/screenshots-folder/cypress/e2e/test2.cy.js
+++ b/examples/screenshots-folder/cypress/e2e/test2.cy.js
@@ -12,4 +12,8 @@ describe('Test 2', () => {
       cy.addTestContext(`There were ${$liElements.length.toString()} items found in the todo-list`);
     });
   });
+
+  it.skip('skipped test', () => {
+    cy.visit('site/index.html');
+  });
 });

--- a/examples/simple-typescript/cypress/e2e/test2.cy.ts
+++ b/examples/simple-typescript/cypress/e2e/test2.cy.ts
@@ -12,4 +12,8 @@ describe('Test 2', () => {
       cy.addTestContext(`There were ${$liElements.length.toString()} items found in the todo-list`);
     });
   });
+
+  it.skip('skipped test', () => {
+    cy.visit('site/index.html');
+  });
 });

--- a/examples/simple/cypress/e2e/test2.cy.js
+++ b/examples/simple/cypress/e2e/test2.cy.js
@@ -12,4 +12,8 @@ describe('Test 2', () => {
       cy.addTestContext(`There were ${$liElements.length.toString()} items found in the todo-list`);
     });
   });
+
+  it.skip('skipped test', () => {
+    cy.visit('site/index.html');
+  });
 });

--- a/lib/enhanceReport.js
+++ b/lib/enhanceReport.js
@@ -104,7 +104,7 @@ function attachMediaToTestContext(context, mochawesomeOptions, screenshotsDir, b
     debugLog(`videos type: ${typeof video}. value: ${JSON.stringify(video)}`);
     if (
       !mochawesomeOptions.ignoreVideos &&
-      (title !== 'cypress-mochawesome-reporter-videos-passed' || !mochawesomeOptions.videoOnFailOnly)
+      (!['cypress-mochawesome-reporter-videos-passed', 'cypress-mochawesome-reporter-videos-pending'].includes(title) || !mochawesomeOptions.videoOnFailOnly)
     ) {
       parsedContext = parsedContext.concat(createVideoContext(video, baseFolder));
     }

--- a/lib/enhanceReport.js
+++ b/lib/enhanceReport.js
@@ -104,7 +104,7 @@ function attachMediaToTestContext(context, mochawesomeOptions, screenshotsDir, b
     debugLog(`videos type: ${typeof video}. value: ${JSON.stringify(video)}`);
     if (
       !mochawesomeOptions.ignoreVideos &&
-      (!['cypress-mochawesome-reporter-videos-passed', 'cypress-mochawesome-reporter-videos-pending'].includes(title) || !mochawesomeOptions.videoOnFailOnly)
+      (title === 'cypress-mochawesome-reporter-videos-failed' || !mochawesomeOptions.videoOnFailOnly)
     ) {
       parsedContext = parsedContext.concat(createVideoContext(video, baseFolder));
     }


### PR DESCRIPTION
Fixed videoOnFailOnly option adding videos to tests skipped by mocha .skip flag.

Added tests to verify videos being added correctly.