### PR TITLE
feat: add support for cypress-cucumber-preprocessor

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ Zero config Mochawesome reporter for Cypress with screenshots attached to tests.
    import 'cypress-mochawesome-reporter/cucumberSupport';
    ```
 
+   > ⚠️ `cypress-cucumber-preprocessor` uses the same hooks as `cypress-mochawesome-reporter`, you also need to install [cypress-on-fix](https://github.com/bahmutov/cypress-on-fix).
+
 5. run cypress
 
 ## Custom options

--- a/README.md
+++ b/README.md
@@ -84,7 +84,13 @@ Zero config Mochawesome reporter for Cypress with screenshots attached to tests.
    import 'cypress-mochawesome-reporter/register';
    ```
 
-4. run cypress
+4. (optional, if your are using `cypress-cucumber-preprocessor`) Add to `cypress/support/step_definitions/index.js`
+
+   ```javascript
+   import 'cypress-mochawesome-reporter/cucumberSupport';
+   ```
+
+5. run cypress
 
 ## Custom options
 

--- a/cucumberSupport.js
+++ b/cucumberSupport.js
@@ -4,31 +4,26 @@ const consts = require('./lib/consts');
 /**
  * Store the Cucumber source in the context for later usage
  */
-Before(() => {
-    const gherkinDocument = window.testState?.gherkinDocument;
-    const pickle = window.testState?.pickle;
+Before(({ pickle, gherkinDocument }) => {
+    // (poor-man deep copy)
+    const gherkinDocumentWithSingleScenario = JSON.parse(JSON.stringify({
+        ...gherkinDocument,
+        feature: {
+            ...gherkinDocument.feature,
+            // keep only the scenario corresponding to the current pickle
+            children: gherkinDocument.feature.children.filter(f => f.scenario?.id === pickle.astNodeIds[0]),
+        },
+    }));
 
-    if (gherkinDocument && pickle) {
-        // (poor-man deep copy)
-        const gherkinDocumentWithSingleScenario = JSON.parse(JSON.stringify({
-            ...gherkinDocument,
-            feature: {
-                ...gherkinDocument.feature,
-                // keep only the scenario corresponding to the current pickle
-                children: gherkinDocument.feature.children.filter(f => f.scenario?.id === pickle.astNodeIds[0]),
-            },
-        }));
-
-        // for scenario outlines, only keep the corresponding example
-        const scenario = gherkinDocumentWithSingleScenario.feature.children[0].scenario;
-        if (scenario.examples.length) {
-            const example = scenario.examples[0];
-            example.tableBody = example.tableBody.filter(row => row.id === pickle.astNodeIds[1]);
-        }
-
-        cy.addTestContext({
-            title: consts.cucumberStepsContextKey,
-            value: gherkinDocumentWithSingleScenario,
-        });
+    // for scenario outlines, only keep the corresponding example
+    const scenario = gherkinDocumentWithSingleScenario.feature.children[0].scenario;
+    if (scenario.examples.length) {
+        const example = scenario.examples[0];
+        example.tableBody = example.tableBody.filter(row => row.id === pickle.astNodeIds[1]);
     }
+
+    cy.addTestContext({
+        title: consts.cucumberStepsContextKey,
+        value: gherkinDocumentWithSingleScenario,
+    });
 });

--- a/cucumberSupport.js
+++ b/cucumberSupport.js
@@ -1,0 +1,34 @@
+const { Before } = require('@badeball/cypress-cucumber-preprocessor');
+const consts = require('./lib/consts');
+
+/**
+ * Store the Cucumber source in the context for later usage
+ */
+Before(() => {
+    const gherkinDocument = window.testState?.gherkinDocument;
+    const pickle = window.testState?.pickle;
+
+    if (gherkinDocument && pickle) {
+        // (poor-man deep copy)
+        const gherkinDocumentWithSingleScenario = JSON.parse(JSON.stringify({
+            ...gherkinDocument,
+            feature: {
+                ...gherkinDocument.feature,
+                // keep only the scenario corresponding to the current pickle
+                children: gherkinDocument.feature.children.filter(f => f.scenario?.id === pickle.astNodeIds[0]),
+            },
+        }));
+
+        // for scenario outlines, only keep the corresponding example
+        const scenario = gherkinDocumentWithSingleScenario.feature.children[0].scenario;
+        if (scenario.examples.length) {
+            const example = scenario.examples[0];
+            example.tableBody = example.tableBody.filter(row => row.id === pickle.astNodeIds[1]);
+        }
+
+        cy.addTestContext({
+            title: consts.cucumberStepsContextKey,
+            value: gherkinDocumentWithSingleScenario,
+        });
+    }
+});

--- a/examples/cucumber/.gitignore
+++ b/examples/cucumber/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+cypress/reports
+cypress/screenshots
+cypress/videos

--- a/examples/cucumber/cypress.config.js
+++ b/examples/cucumber/cypress.config.js
@@ -1,0 +1,31 @@
+const { defineConfig } = require('cypress');
+const cypressOnFix = require('cypress-on-fix');
+const createBundler = require('@bahmutov/cypress-esbuild-preprocessor');
+const { addCucumberPreprocessorPlugin } = require('@badeball/cypress-cucumber-preprocessor');
+const { createEsbuildPlugin } = require('@badeball/cypress-cucumber-preprocessor/esbuild');
+
+module.exports = defineConfig({
+  reporter: 'cypress-mochawesome-reporter',
+  video: true,
+  retries: 1,
+  e2e: {
+    specPattern: 'cypress/e2e/**/*.feature',
+    async setupNodeEvents(on, config) {
+      // "cypress-on-fix" is required because "cypress-mochawesome-reporter" and "cypress-cucumber-preprocessor" use the same hooks
+      on = cypressOnFix(on);
+
+      require('cypress-mochawesome-reporter/plugin')(on);
+
+      await addCucumberPreprocessorPlugin(on, config);
+
+      on(
+        'file:preprocessor',
+        createBundler({
+          plugins: [createEsbuildPlugin(config)],
+        })
+      );
+
+      return config;
+    },
+  },
+});

--- a/examples/cucumber/cypress/e2e/test1.feature
+++ b/examples/cucumber/cypress/e2e/test1.feature
@@ -7,3 +7,13 @@ Feature: Test 1
     Scenario: fail
         When I visit "site/index.html"
         Then The list has 5 items
+
+    Scenario Outline: pass with examples
+        When I visit "site/index.html"
+        Then The list has more than <num> items
+
+        Examples:
+            | num |
+            | 1   |
+            | 2   |
+            | 3   |

--- a/examples/cucumber/cypress/e2e/test1.feature
+++ b/examples/cucumber/cypress/e2e/test1.feature
@@ -1,0 +1,9 @@
+Feature: Test 1
+
+    Scenario: pass
+        When I visit "site/index.html"
+        Then The list has 4 items
+
+    Scenario: fail
+        When I visit "site/index.html"
+        Then The list has 5 items

--- a/examples/cucumber/cypress/support/e2e.js
+++ b/examples/cucumber/cypress/support/e2e.js
@@ -1,0 +1,22 @@
+// ***********************************************************
+// This example support/index.js is processed and
+// loaded automatically before your test files.
+//
+// This is a great place to put global configuration and
+// behavior that modifies Cypress.
+//
+// You can change the location of this file or turn off
+// automatically serving support files with the
+// 'supportFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/configuration
+// ***********************************************************
+
+// Import commands.js using ES2015 syntax:
+import './commands';
+
+import 'cypress-mochawesome-reporter/register';
+
+// Alternatively you can use CommonJS syntax:
+// require('./commands')

--- a/examples/cucumber/cypress/support/step_definitions/index.js
+++ b/examples/cucumber/cypress/support/step_definitions/index.js
@@ -8,3 +8,7 @@ When(`I visit {string}`, (url) => {
 Then(`The list has {int} items`, (nb) => {
     cy.get('#todo-list li').should('have.length', nb);
 });
+
+Then(`The list has more than {int} items`, (nb) => {
+    cy.get('#todo-list li').should('have.length.greaterThan', nb);
+});

--- a/examples/cucumber/cypress/support/step_definitions/index.js
+++ b/examples/cucumber/cypress/support/step_definitions/index.js
@@ -1,0 +1,10 @@
+import 'cypress-mochawesome-reporter/cucumberSupport';
+import { When, Then } from '@badeball/cypress-cucumber-preprocessor';
+
+When(`I visit {string}`, (url) => {
+    cy.visit(url);
+});
+
+Then(`The list has {int} items`, (nb) => {
+    cy.get('#todo-list li').should('have.length', nb);
+});

--- a/examples/cucumber/package.json
+++ b/examples/cucumber/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@example/cucumber",
+  "version": "1.0.0",
+  "scripts": {
+    "cypress:open": "cypress open",
+    "test": "cypress run"
+  },
+  "license": "MIT",
+  "devDependencies": {
+    "cypress": "^13.1.0",
+    "cypress-on-fix": "^1.0.2",
+    "cypress-mochawesome-reporter": "../../"
+  }
+}

--- a/examples/cucumber/site/index.html
+++ b/examples/cucumber/site/index.html
@@ -1,0 +1,11 @@
+<html>
+  <body>
+    <h1>TODO list</h1>
+    <ul id="todo-list">
+      <li>todo1</li>
+      <li>todo2</li>
+      <li>todo3</li>
+      <li>todo4</li>
+    </ul>
+  </body>
+</html>

--- a/lib/consts.js
+++ b/lib/consts.js
@@ -1,6 +1,5 @@
-const path = require('path');
-
 module.exports = {
   defaultHtmlOutputFolder: 'cypress/reports/html',
   defaultConfigOutput: 'cypress/.tmp/cypressMochawesomeReporterConfig.json',
+  cucumberStepsContextKey: '__cucumber_source__',
 };

--- a/lib/enhanceReport.js
+++ b/lib/enhanceReport.js
@@ -202,7 +202,10 @@ function extrapolateBaseFolder(results) {
  */
 function setCucumberCode(test) {
   if (test.context) {
-    const context = JSON.parse(test.context);
+    let context = JSON.parse(test.context);
+    if (!Array.isArray(context)) {
+      context = [context];
+    }
     // the context can be encountered multiple times if the test is retried
     // only use the first occurence but remove of all them from the context
     const cucumberFound = context.some(({ title, value }) => {

--- a/lib/enhanceReport.js
+++ b/lib/enhanceReport.js
@@ -1,6 +1,12 @@
 const path = require('path');
 const fse = require('fs-extra');
-const { debugLog, log } = require('./logger');
+const { debugLog } = require('./logger');
+const consts = require('./consts');
+
+let gherkin;
+try {
+  gherkin = require('@cucumber/gherkin-utils');
+} catch {}
 
 function enhanceReport(report, mochawesomeOptions, screenshotsDir) {
   const baseFolder = extrapolateBaseFolder(report.results);
@@ -13,6 +19,9 @@ function enhanceReport(report, mochawesomeOptions, screenshotsDir) {
       suites.forEach((suite) => {
         suite.file = file;
         suite.fullFile = fullFile;
+        suite.tests.forEach((test) => {
+          setCucumberCode(test);
+        });
       });
       attachMediaToSuiteTestsContext(result.suites, mochawesomeOptions, screenshotsDir, baseFolder);
     }
@@ -22,6 +31,7 @@ function enhanceReport(report, mochawesomeOptions, screenshotsDir) {
       tests.forEach((test) => {
         debugLog(`attach screenshots for test "${test.fullTitle}"`);
         test.context = attachMediaToTestContext(test.context, mochawesomeOptions, screenshotsDir, baseFolder);
+        setCucumberCode(test);
       });
     }
   });
@@ -185,6 +195,32 @@ function extrapolateBaseFolder(results) {
   const baseFolder = commonPathArray.join(path.sep);
   debugLog(`baseFolder: ${baseFolder}`);
   return baseFolder;
+}
+
+/**
+ * if '__cucumber_source__' is found in the context, beautify it an replace the code block
+ */
+function setCucumberCode(test) {
+  if (test.context) {
+    const context = JSON.parse(test.context);
+    for (let i = 0; i < context.length; i++) {
+      if (context[i].title === consts.cucumberStepsContextKey) {
+        test.code = beautifyCucumber(context[i].value);
+        context.splice(i, 1);
+        test.context = JSON.stringify(context);
+        break;
+      }
+    }
+  }
+}
+
+function beautifyCucumber(gherkinDocument) {
+  if (!gherkin) {
+    console.error('@cucumber/gherkin-utils is not available');
+    return 'ERROR: @cucumber/gherkin-utils is not available';
+  }
+
+  return gherkin.pretty(gherkinDocument, 'gherkin');
 }
 
 module.exports = {

--- a/lib/enhanceReport.js
+++ b/lib/enhanceReport.js
@@ -203,13 +203,16 @@ function extrapolateBaseFolder(results) {
 function setCucumberCode(test) {
   if (test.context) {
     const context = JSON.parse(test.context);
-    for (let i = 0; i < context.length; i++) {
-      if (context[i].title === consts.cucumberStepsContextKey) {
-        test.code = beautifyCucumber(context[i].value);
-        context.splice(i, 1);
-        test.context = JSON.stringify(context);
-        break;
+    // the context can be encountered multiple times if the test is retried
+    // only use the first occurence but remove of all them from the context
+    const cucumberFound = context.some(({ title, value }) => {
+      if (title === consts.cucumberStepsContextKey) {
+        test.code = beautifyCucumber(value);
+        return true;
       }
+    });
+    if (cucumberFound) {
+      test.context = JSON.stringify(context.filter(({ title }) => title !== consts.cucumberStepsContextKey));
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
     "mochawesome-report-generator": "^6.2.0"
   },
   "devDependencies": {
+    "@badeball/cypress-cucumber-preprocessor": "^19.2.0",
+    "@bahmutov/cypress-esbuild-preprocessor": "^2.2.0",
     "cypress": "^13.1.0",
     "lerna": "^7.1.4"
   },


### PR DESCRIPTION
This solves #130

Users of `cypress-cucumber-preprocessor` will be able to import `cucumberSupport` in their steps in order to store the gherkin AST in the test context. During the report generation the context will be used to remplace the code by the actual gherkin.

I tried to keep the modification as light as possible without adding any required dependencies. 
- `@badeball/cypress-cucumber-preprocessor` is only imported in `cucumberSupport.js`
- `@cucumber/gherkin-utils` is imported inside a try-catch block in `enhanceReport.js`

All of this is optionnal allowing to mix Cucumber features and standard tests in the same suite.

---

There is still need to add tests, for now I cannot tell when I will be able to do it.