### PR TITLE
fix: missing "Background" in Cucumber steps

### DIFF
--- a/cucumberSupport.js
+++ b/cucumberSupport.js
@@ -11,12 +11,12 @@ Before(({ pickle, gherkinDocument }) => {
         feature: {
             ...gherkinDocument.feature,
             // keep only the scenario corresponding to the current pickle
-            children: gherkinDocument.feature.children.filter(f => f.scenario?.id === pickle.astNodeIds[0]),
+            children: gherkinDocument.feature.children.filter(f => !f.scenario || f.scenario.id === pickle.astNodeIds[0]),
         },
     }));
 
     // for scenario outlines, only keep the corresponding example
-    const scenario = gherkinDocumentWithSingleScenario.feature.children[0].scenario;
+    const scenario = gherkinDocumentWithSingleScenario.feature.children.filter(f => f.scenario)[0]?.scenario;
     if (scenario.examples.length) {
         const example = scenario.examples[0];
         example.tableBody = example.tableBody.filter(row => row.id === pickle.astNodeIds[1]);

--- a/cypress/e2e/cucumber.cy.js
+++ b/cypress/e2e/cucumber.cy.js
@@ -29,9 +29,10 @@ describe(`cucumber folder`, () => {
         'pass',
         `
 Feature: Test 1
+  Background:
+    When I visit "site/index.html"
 
   Scenario: pass
-    When I visit "site/index.html"
     Then The list has 4 items
 `
       );
@@ -42,9 +43,10 @@ Feature: Test 1
         'fail',
         `
 Feature: Test 1
+  Background:
+    When I visit "site/index.html"
 
   Scenario: fail
-    When I visit "site/index.html"
     Then The list has 5 items
 `
       );
@@ -55,9 +57,10 @@ Feature: Test 1
         'pass with examples (example #1)',
         `
 Feature: Test 1
+  Background:
+    When I visit "site/index.html"
 
   Scenario Outline: pass with examples
-    When I visit "site/index.html"
     Then The list has more than <num> items
 
     Examples: 
@@ -72,9 +75,10 @@ Feature: Test 1
         'pass with examples (example #2)',
         `
 Feature: Test 1
+  Background:
+    When I visit "site/index.html"
 
   Scenario Outline: pass with examples
-    When I visit "site/index.html"
     Then The list has more than <num> items
 
     Examples: 
@@ -89,9 +93,10 @@ Feature: Test 1
         'pass with examples (example #3)',
         `
 Feature: Test 1
+  Background:
+    When I visit "site/index.html"
 
   Scenario Outline: pass with examples
-    When I visit "site/index.html"
     Then The list has more than <num> items
 
     Examples: 

--- a/examples/cucumber/cypress/e2e/test1.feature
+++ b/examples/cucumber/cypress/e2e/test1.feature
@@ -1,15 +1,14 @@
 Feature: Test 1
+    Background:
+        When I visit "site/index.html"
 
     Scenario: pass
-        When I visit "site/index.html"
         Then The list has 4 items
 
     Scenario: fail
-        When I visit "site/index.html"
         Then The list has 5 items
 
     Scenario Outline: pass with examples
-        When I visit "site/index.html"
         Then The list has more than <num> items
 
         Examples:


### PR DESCRIPTION
Today I created by first test using "Background" and saw that the corresponding block is missing in the report.

I modified the filter applied to the AST to actually filter out the scenarii but not others stuff