### PR TITLE
fix: Change precedence of default options

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -10,8 +10,8 @@ const defaultReporterOptions = {
 
 function reporter(runner, options) {
   const reporterOptions = {
-    ...(options || {}).reporterOptions,
     ...defaultReporterOptions,
+    ...(options || {}).reporterOptions,
   };
 
   reporterOptions['reportDir'] = path.join(reporterOptions['reportDir'] || consts.defaultHtmlOutputFolder, '/.jsons');


### PR DESCRIPTION
The defaultReporterOptions overwrite the configured options, instead of the other way around.

When running e2e tests with `cypress-repeat`, the subsequent runs of a failed test should replace the report of the previous run. Even when setting `overwrite` to true in the reporter options, a new report file with a sequence number is still created. I traced the problem back to this point.