### PR TITLE
Fix #217

### DIFF
--- a/lib/enhanceReport.js
+++ b/lib/enhanceReport.js
@@ -179,7 +179,7 @@ function extrapolateBaseFolder(results) {
   const directoryArrays = results.map((result) =>
       path.dirname(result.fullFile).split(path.sep)
   );
-  const minLength = Math.min(...directoryArrays.map((arr) => arr.length));
+  const minLength = Math.min(0, ...directoryArrays.map((arr) => arr.length));
   let commonPathArray = [];
 
   for (let i = 0; i < minLength; i++) {


### PR DESCRIPTION
Running Math.min() without parameters returns `Infinity`. If for some reason directoryArrays is empty, `minLength` will be `Infinity`, resulting in `RangeError: Invalid array length`