### PR TITLE
Handling no available json report

### DIFF
--- a/lib/generateReport.js
+++ b/lib/generateReport.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const glob = require('glob');
 const fse = require('fs-extra');
 const { merge } = require('mochawesome-merge');
 const reportGenerator = require('mochawesome-report-generator');
@@ -9,9 +10,15 @@ const { enhanceReport } = require('./enhanceReport');
 async function mergeAndCreate(jsonDir, screenshotsDir, mochawesomeOptions) {
   log(`Read and merge jsons from "${jsonDir}"`);
 
-  const report = await merge({
-    files: [jsonDir.concat('/*.json')],
-  });
+  const pattern = path.join(jsonDir, '*.json');
+  const files = await globAsync(pattern);
+
+  if (files.length === 0) {
+    log('No JSON files found. Skipping report generation.');
+    return null;
+  }
+
+  const report = await merge({ files });
 
   debugLog(`report before enhance: ${JSON.stringify(report)}`);
 


### PR DESCRIPTION
Sometimes when running tests in parallel, if I just have 1 spec file and more than 1 available job to run my Cypress tests the extra jobs will not have any spec file to run, so we will not generate any json report in this case, currently if we don't have any json available the library still tries to Read and merge jsons from and it fails on merge, with this fix I hope we can bypass this error when no jsons are available due parallelization