### PR TITLE
fix: Revert "fix: Generating reports with empty tests (#218)"

### DIFF
--- a/lib/enhanceReport.js
+++ b/lib/enhanceReport.js
@@ -179,7 +179,7 @@ function extrapolateBaseFolder(results) {
   const directoryArrays = results.map((result) =>
       path.dirname(result.fullFile).split(path.sep)
   );
-  const minLength = Math.min(0, ...directoryArrays.map((arr) => arr.length));
+  const minLength = Math.min(...directoryArrays.map((arr) => arr.length));
   let commonPathArray = [];
 
   for (let i = 0; i < minLength; i++) {


### PR DESCRIPTION
This reverts commit c6c5c6610fbb76ec788847d51da367ca65a8cae2.