### PR TITLE
fix: Generating reports with empty tests

### DIFF
--- a/lib/enhanceReport.js
+++ b/lib/enhanceReport.js
@@ -180,9 +180,11 @@ function extrapolateBaseFolder(results) {
       path.dirname(result.fullFile).split(path.sep)
   );
   const minLength = Math.min(...directoryArrays.map((arr) => arr.length));
+  // if directoryArrays is empty, Math.min will return Infinity
+  const finiteMinLength = Number.isFinite(minLength) ? minLength : 0
   let commonPathArray = [];
 
-  for (let i = 0; i < minLength; i++) {
+  for (let i = 0; i < finiteMinLength; i++) {
     const elementsAtCurrentIndex = directoryArrays.map((arr) => arr[i]);
 
     if (allElementsEqual(elementsAtCurrentIndex)) {


### PR DESCRIPTION
Sorry for the mistake in https://github.com/LironEr/cypress-mochawesome-reporter/pull/218

This really fix #217 