### PR TITLE
refactor: Remove mochawesome-merge dependency

### DIFF
--- a/lib/generateReport.js
+++ b/lib/generateReport.js
@@ -26,7 +26,7 @@ async function mergeReports(jsonDir) {
 }
 
 function getAllTests(suites) {
-  return suites.flatMap((suite) => [...suite.tests, ...getAllTests(suite.suites)]);
+  return (suites ?? []).flatMap((suite) => [...(suite.tests ?? []), ...getAllTests(suite.suites ?? [])]);
 }
 
 function generateStats(suites, reports) {

--- a/lib/generateReport.js
+++ b/lib/generateReport.js
@@ -1,17 +1,62 @@
 const path = require('path');
 const fse = require('fs-extra');
-const { merge } = require('mochawesome-merge');
 const reportGenerator = require('mochawesome-report-generator');
 const { getConfig } = require('./config');
 const { log, debugLog } = require('./logger');
 const { enhanceReport } = require('./enhanceReport');
 
+async function mergeReports(jsonDir) {
+  const files = (await fse.readdir(jsonDir))
+    .filter((file) => file.endsWith('.json'))
+    .sort()
+    .map((file) => path.join(jsonDir, file));
+
+  if (files.length === 0) {
+    throw new Error(`No mochawesome report JSON files found in "${jsonDir}"`);
+  }
+
+  const reports = await Promise.all(files.map((file) => fse.readJson(file)));
+  const stats = mergeStats(reports.map((report) => report.stats || {}));
+
+  return {
+    ...reports[0],
+    stats,
+    results: reports.flatMap((report) => report.results || []),
+  };
+}
+
+function mergeStats(statsList) {
+  const startTimes = statsList.map((stats) => Date.parse(stats.start)).filter(Number.isFinite);
+  const endTimes = statsList.map((stats) => Date.parse(stats.end)).filter(Number.isFinite);
+  const sum = (field) => statsList.reduce((total, stats) => total + (Number(stats[field]) || 0), 0);
+  const tests = sum('tests');
+  const passes = sum('passes');
+  const pending = sum('pending');
+
+  return {
+    suites: sum('suites'),
+    tests,
+    passes,
+    pending,
+    failures: sum('failures'),
+    skipped: sum('skipped'),
+    testsRegistered: sum('testsRegistered') || tests,
+    passPercent: tests > 0 ? (passes / tests) * 100 : 0,
+    pendingPercent: tests > 0 ? (pending / tests) * 100 : 0,
+    other: sum('other'),
+    hasOther: statsList.some((stats) => !!stats.hasOther),
+    skippedHooks: sum('skippedHooks'),
+    hasSkippedHooks: statsList.some((stats) => !!stats.hasSkippedHooks),
+    start: startTimes.length > 0 ? new Date(Math.min(...startTimes)).toISOString() : undefined,
+    end: endTimes.length > 0 ? new Date(Math.max(...endTimes)).toISOString() : undefined,
+    duration: sum('duration'),
+  };
+}
+
 async function mergeAndCreate(jsonDir, screenshotsDir, mochawesomeOptions) {
   log(`Read and merge jsons from "${jsonDir}"`);
 
-  const report = await merge({
-    files: [jsonDir.concat('/*.json')],
-  });
+  const report = await mergeReports(jsonDir);
 
   debugLog(`report before enhance: ${JSON.stringify(report)}`);
 
@@ -74,3 +119,4 @@ async function generateReport() {
 }
 
 module.exports = generateReport;
+module.exports.mergeReports = mergeReports;

--- a/lib/generateReport.js
+++ b/lib/generateReport.js
@@ -16,40 +16,44 @@ async function mergeReports(jsonDir) {
   }
 
   const reports = await Promise.all(files.map((file) => fse.readJson(file)));
-  const stats = mergeStats(reports.map((report) => report.stats || {}));
+  const results = reports.flatMap((report) => report.results.filter((result) => result !== false));
 
   return {
-    ...reports[0],
-    stats,
-    results: reports.flatMap((report) => report.results || []),
+    stats: generateStats(results, reports),
+    results,
+    meta: reports[0].meta,
   };
 }
 
-function mergeStats(statsList) {
-  const startTimes = statsList.map((stats) => Date.parse(stats.start)).filter(Number.isFinite);
-  const endTimes = statsList.map((stats) => Date.parse(stats.end)).filter(Number.isFinite);
-  const sum = (field) => statsList.reduce((total, stats) => total + (Number(stats[field]) || 0), 0);
-  const tests = sum('tests');
-  const passes = sum('passes');
-  const pending = sum('pending');
+function getAllTests(suites) {
+  return suites.flatMap((suite) => [...suite.tests, ...getAllTests(suite.suites)]);
+}
+
+function generateStats(suites, reports) {
+  const tests = getAllTests(suites);
+  const passes = tests.filter((test) => test.state === 'passed');
+  const pending = tests.filter((test) => test.state === 'pending');
+  const failures = tests.filter((test) => test.state === 'failed');
+  const skipped = tests.filter((test) => test.state === 'skipped');
+  const start = new Date(Math.min(...reports.map((report) => new Date(report.stats.start).getTime())));
+  const end = new Date(Math.max(...reports.map((report) => new Date(report.stats.end).getTime())));
 
   return {
-    suites: sum('suites'),
-    tests,
-    passes,
-    pending,
-    failures: sum('failures'),
-    skipped: sum('skipped'),
-    testsRegistered: sum('testsRegistered') || tests,
-    passPercent: tests > 0 ? (passes / tests) * 100 : 0,
-    pendingPercent: tests > 0 ? (pending / tests) * 100 : 0,
-    other: sum('other'),
-    hasOther: statsList.some((stats) => !!stats.hasOther),
-    skippedHooks: sum('skippedHooks'),
-    hasSkippedHooks: statsList.some((stats) => !!stats.hasSkippedHooks),
-    start: startTimes.length > 0 ? new Date(Math.min(...startTimes)).toISOString() : undefined,
-    end: endTimes.length > 0 ? new Date(Math.max(...endTimes)).toISOString() : undefined,
-    duration: sum('duration'),
+    suites: suites.length,
+    tests: tests.length,
+    passes: passes.length,
+    pending: pending.length,
+    failures: failures.length,
+    testsRegistered: tests.length,
+    passPercent: (passes.length * 100) / tests.length,
+    pendingPercent: (pending.length * 100) / tests.length,
+    other: 0,
+    hasOther: false,
+    skipped: skipped.length,
+    hasSkipped: skipped.length > 0,
+    start: start.toISOString(),
+    end: end.toISOString(),
+    duration: end.getTime() - start.getTime(),
   };
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "commander": "^10.0.1",
         "fs-extra": "^11.3.0",
-        "mochawesome": "^7.1.4",
+        "mochawesome": "^7.1.3",
         "mochawesome-report-generator": "^6.2.0"
       },
       "bin": {
@@ -8918,10 +8918,9 @@
       }
     },
     "node_modules/mochawesome": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/mochawesome/-/mochawesome-7.1.4.tgz",
-      "integrity": "sha512-fucGSh8643QkSvNRFOaJ3+kfjF0FhA/YtvDncnRAG0A4oCtAzHIFkt/+SgsWil1uwoeT+Nu5fsAnrKkFtnPcZQ==",
-      "license": "MIT",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/mochawesome/-/mochawesome-7.1.3.tgz",
+      "integrity": "sha512-Vkb3jR5GZ1cXohMQQ73H3cZz7RoxGjjUo0G5hu0jLaW+0FdUxUwg3Cj29bqQdh0rFcnyV06pWmqmi5eBPnEuNQ==",
       "dependencies": {
         "chalk": "^4.1.2",
         "diff": "^5.0.0",
@@ -8930,7 +8929,7 @@
         "lodash.isfunction": "^3.0.9",
         "lodash.isobject": "^3.0.2",
         "lodash.isstring": "^4.0.1",
-        "mochawesome-report-generator": "^6.3.0",
+        "mochawesome-report-generator": "^6.2.0",
         "strip-ansi": "^6.0.1",
         "uuid": "^8.3.2"
       },
@@ -8939,10 +8938,9 @@
       }
     },
     "node_modules/mochawesome-report-generator": {
-      "version": "6.3.2",
-      "resolved": "https://registry.npmjs.org/mochawesome-report-generator/-/mochawesome-report-generator-6.3.2.tgz",
-      "integrity": "sha512-iB6iyOUMyMr8XOUYTNfrqYuZQLZka3K/Gr2GPc6CHPe7t2ZhxxfcoVkpMLOtyDKnWbY1zgu1/7VNRsigrvKnOQ==",
-      "license": "MIT",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/mochawesome-report-generator/-/mochawesome-report-generator-6.2.0.tgz",
+      "integrity": "sha512-Ghw8JhQFizF0Vjbtp9B0i//+BOkV5OWcQCPpbO0NGOoxV33o+gKDYU0Pr2pGxkIHnqZ+g5mYiXF7GMNgAcDpSg==",
       "dependencies": {
         "chalk": "^4.1.2",
         "dateformat": "^4.5.1",
@@ -8954,6 +8952,7 @@
         "prop-types": "^15.7.2",
         "tcomb": "^3.2.17",
         "tcomb-validation": "^3.3.0",
+        "validator": "^13.6.0",
         "yargs": "^17.2.1"
       },
       "bin": {
@@ -12941,6 +12940,14 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/validator": {
+      "version": "13.15.23",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.23.tgz",
+      "integrity": "sha512-4yoz1kEWqUjzi5zsPbAS/903QXSYp0UOtHsPpp7p9rHAw/W+dkInskAE386Fat3oKRROwO98d9ZB0G4cObgUyw==",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/verror": {
@@ -19630,9 +19637,9 @@
       }
     },
     "mochawesome": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/mochawesome/-/mochawesome-7.1.4.tgz",
-      "integrity": "sha512-fucGSh8643QkSvNRFOaJ3+kfjF0FhA/YtvDncnRAG0A4oCtAzHIFkt/+SgsWil1uwoeT+Nu5fsAnrKkFtnPcZQ==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/mochawesome/-/mochawesome-7.1.3.tgz",
+      "integrity": "sha512-Vkb3jR5GZ1cXohMQQ73H3cZz7RoxGjjUo0G5hu0jLaW+0FdUxUwg3Cj29bqQdh0rFcnyV06pWmqmi5eBPnEuNQ==",
       "requires": {
         "chalk": "^4.1.2",
         "diff": "^5.0.0",
@@ -19641,15 +19648,15 @@
         "lodash.isfunction": "^3.0.9",
         "lodash.isobject": "^3.0.2",
         "lodash.isstring": "^4.0.1",
-        "mochawesome-report-generator": "^6.3.0",
+        "mochawesome-report-generator": "^6.2.0",
         "strip-ansi": "^6.0.1",
         "uuid": "^8.3.2"
       }
     },
     "mochawesome-report-generator": {
-      "version": "6.3.2",
-      "resolved": "https://registry.npmjs.org/mochawesome-report-generator/-/mochawesome-report-generator-6.3.2.tgz",
-      "integrity": "sha512-iB6iyOUMyMr8XOUYTNfrqYuZQLZka3K/Gr2GPc6CHPe7t2ZhxxfcoVkpMLOtyDKnWbY1zgu1/7VNRsigrvKnOQ==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/mochawesome-report-generator/-/mochawesome-report-generator-6.2.0.tgz",
+      "integrity": "sha512-Ghw8JhQFizF0Vjbtp9B0i//+BOkV5OWcQCPpbO0NGOoxV33o+gKDYU0Pr2pGxkIHnqZ+g5mYiXF7GMNgAcDpSg==",
       "requires": {
         "chalk": "^4.1.2",
         "dateformat": "^4.5.1",
@@ -19661,6 +19668,7 @@
         "prop-types": "^15.7.2",
         "tcomb": "^3.2.17",
         "tcomb-validation": "^3.3.0",
+        "validator": "^13.6.0",
         "yargs": "^17.2.1"
       },
       "dependencies": {
@@ -22561,6 +22569,11 @@
       "requires": {
         "builtins": "^5.0.0"
       }
+    },
+    "validator": {
+      "version": "13.15.23",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.23.tgz",
+      "integrity": "sha512-4yoz1kEWqUjzi5zsPbAS/903QXSYp0UOtHsPpp7p9rHAw/W+dkInskAE386Fat3oKRROwO98d9ZB0G4cObgUyw=="
     },
     "verror": {
       "version": "1.10.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,7 @@
       "dependencies": {
         "commander": "^10.0.1",
         "fs-extra": "^11.3.0",
-        "mochawesome": "^7.1.3",
-        "mochawesome-merge": "^5.0.0",
+        "mochawesome": "^7.1.4",
         "mochawesome-report-generator": "^6.2.0"
       },
       "bin": {
@@ -1648,27 +1647,6 @@
         "@types/node": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@isaacs/balanced-match": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
-      "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@isaacs/brace-expansion": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
-      "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
-      "license": "MIT",
-      "dependencies": {
-        "@isaacs/balanced-match": "^4.0.1"
-      },
-      "engines": {
-        "node": "20 || >=22"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -8940,9 +8918,10 @@
       }
     },
     "node_modules/mochawesome": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/mochawesome/-/mochawesome-7.1.3.tgz",
-      "integrity": "sha512-Vkb3jR5GZ1cXohMQQ73H3cZz7RoxGjjUo0G5hu0jLaW+0FdUxUwg3Cj29bqQdh0rFcnyV06pWmqmi5eBPnEuNQ==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/mochawesome/-/mochawesome-7.1.4.tgz",
+      "integrity": "sha512-fucGSh8643QkSvNRFOaJ3+kfjF0FhA/YtvDncnRAG0A4oCtAzHIFkt/+SgsWil1uwoeT+Nu5fsAnrKkFtnPcZQ==",
+      "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
         "diff": "^5.0.0",
@@ -8951,7 +8930,7 @@
         "lodash.isfunction": "^3.0.9",
         "lodash.isobject": "^3.0.2",
         "lodash.isstring": "^4.0.1",
-        "mochawesome-report-generator": "^6.2.0",
+        "mochawesome-report-generator": "^6.3.0",
         "strip-ansi": "^6.0.1",
         "uuid": "^8.3.2"
       },
@@ -8959,155 +8938,11 @@
         "mocha": ">=7"
       }
     },
-    "node_modules/mochawesome-merge": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/mochawesome-merge/-/mochawesome-merge-5.0.0.tgz",
-      "integrity": "sha512-PuDSJVqiJu++/QlK1EEwRjBJXh00mmWjAemOLnjT7EcBvce4jtSX+WGCZqYDU6igr6ZXP4/eYLcPpW8+6qmBMA==",
-      "license": "MIT",
-      "dependencies": {
-        "fs-extra": "^11.3.0",
-        "glob": "^11.0.1",
-        "yargs": "^17.7.2"
-      },
-      "bin": {
-        "mochawesome-merge": "bin/mochawesome-merge.js"
-      },
-      "engines": {
-        "node": ">=22"
-      }
-    },
-    "node_modules/mochawesome-merge/node_modules/cliui": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/mochawesome-merge/node_modules/glob": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.3.tgz",
-      "integrity": "sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==",
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.3.1",
-        "jackspeak": "^4.1.1",
-        "minimatch": "^10.0.3",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^2.0.0"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/mochawesome-merge/node_modules/jackspeak": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
-      "integrity": "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/mochawesome-merge/node_modules/lru-cache": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.1.0.tgz",
-      "integrity": "sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==",
-      "license": "ISC",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/mochawesome-merge/node_modules/minimatch": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.3.tgz",
-      "integrity": "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==",
-      "license": "ISC",
-      "dependencies": {
-        "@isaacs/brace-expansion": "^5.0.0"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/mochawesome-merge/node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/mochawesome-merge/node_modules/path-scurry": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
-      "integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^11.0.0",
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/mochawesome-merge/node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/mochawesome-merge/node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/mochawesome-report-generator": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/mochawesome-report-generator/-/mochawesome-report-generator-6.2.0.tgz",
-      "integrity": "sha512-Ghw8JhQFizF0Vjbtp9B0i//+BOkV5OWcQCPpbO0NGOoxV33o+gKDYU0Pr2pGxkIHnqZ+g5mYiXF7GMNgAcDpSg==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/mochawesome-report-generator/-/mochawesome-report-generator-6.3.2.tgz",
+      "integrity": "sha512-iB6iyOUMyMr8XOUYTNfrqYuZQLZka3K/Gr2GPc6CHPe7t2ZhxxfcoVkpMLOtyDKnWbY1zgu1/7VNRsigrvKnOQ==",
+      "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
         "dateformat": "^4.5.1",
@@ -9119,7 +8954,6 @@
         "prop-types": "^15.7.2",
         "tcomb": "^3.2.17",
         "tcomb-validation": "^3.3.0",
-        "validator": "^13.6.0",
         "yargs": "^17.2.1"
       },
       "bin": {
@@ -13109,14 +12943,6 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
-    "node_modules/validator": {
-      "version": "13.15.23",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.23.tgz",
-      "integrity": "sha512-4yoz1kEWqUjzi5zsPbAS/903QXSYp0UOtHsPpp7p9rHAw/W+dkInskAE386Fat3oKRROwO98d9ZB0G4cObgUyw==",
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/verror": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
@@ -14582,19 +14408,6 @@
       "requires": {
         "chardet": "^2.1.0",
         "iconv-lite": "^0.6.3"
-      }
-    },
-    "@isaacs/balanced-match": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
-      "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ=="
-    },
-    "@isaacs/brace-expansion": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
-      "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
-      "requires": {
-        "@isaacs/balanced-match": "^4.0.1"
       }
     },
     "@isaacs/cliui": {
@@ -19817,9 +19630,9 @@
       }
     },
     "mochawesome": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/mochawesome/-/mochawesome-7.1.3.tgz",
-      "integrity": "sha512-Vkb3jR5GZ1cXohMQQ73H3cZz7RoxGjjUo0G5hu0jLaW+0FdUxUwg3Cj29bqQdh0rFcnyV06pWmqmi5eBPnEuNQ==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/mochawesome/-/mochawesome-7.1.4.tgz",
+      "integrity": "sha512-fucGSh8643QkSvNRFOaJ3+kfjF0FhA/YtvDncnRAG0A4oCtAzHIFkt/+SgsWil1uwoeT+Nu5fsAnrKkFtnPcZQ==",
       "requires": {
         "chalk": "^4.1.2",
         "diff": "^5.0.0",
@@ -19828,104 +19641,15 @@
         "lodash.isfunction": "^3.0.9",
         "lodash.isobject": "^3.0.2",
         "lodash.isstring": "^4.0.1",
-        "mochawesome-report-generator": "^6.2.0",
+        "mochawesome-report-generator": "^6.3.0",
         "strip-ansi": "^6.0.1",
         "uuid": "^8.3.2"
       }
     },
-    "mochawesome-merge": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/mochawesome-merge/-/mochawesome-merge-5.0.0.tgz",
-      "integrity": "sha512-PuDSJVqiJu++/QlK1EEwRjBJXh00mmWjAemOLnjT7EcBvce4jtSX+WGCZqYDU6igr6ZXP4/eYLcPpW8+6qmBMA==",
-      "requires": {
-        "fs-extra": "^11.3.0",
-        "glob": "^11.0.1",
-        "yargs": "^17.7.2"
-      },
-      "dependencies": {
-        "cliui": {
-          "version": "8.0.1",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-          "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-          "requires": {
-            "string-width": "^4.2.0",
-            "strip-ansi": "^6.0.1",
-            "wrap-ansi": "^7.0.0"
-          }
-        },
-        "glob": {
-          "version": "11.0.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.3.tgz",
-          "integrity": "sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==",
-          "requires": {
-            "foreground-child": "^3.3.1",
-            "jackspeak": "^4.1.1",
-            "minimatch": "^10.0.3",
-            "minipass": "^7.1.2",
-            "package-json-from-dist": "^1.0.0",
-            "path-scurry": "^2.0.0"
-          }
-        },
-        "jackspeak": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
-          "integrity": "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==",
-          "requires": {
-            "@isaacs/cliui": "^8.0.2"
-          }
-        },
-        "lru-cache": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.1.0.tgz",
-          "integrity": "sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A=="
-        },
-        "minimatch": {
-          "version": "10.0.3",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.3.tgz",
-          "integrity": "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==",
-          "requires": {
-            "@isaacs/brace-expansion": "^5.0.0"
-          }
-        },
-        "minipass": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-          "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="
-        },
-        "path-scurry": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
-          "integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
-          "requires": {
-            "lru-cache": "^11.0.0",
-            "minipass": "^7.1.2"
-          }
-        },
-        "yargs": {
-          "version": "17.7.2",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-          "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-          "requires": {
-            "cliui": "^8.0.1",
-            "escalade": "^3.1.1",
-            "get-caller-file": "^2.0.5",
-            "require-directory": "^2.1.1",
-            "string-width": "^4.2.3",
-            "y18n": "^5.0.5",
-            "yargs-parser": "^21.1.1"
-          }
-        },
-        "yargs-parser": {
-          "version": "21.1.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-          "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="
-        }
-      }
-    },
     "mochawesome-report-generator": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/mochawesome-report-generator/-/mochawesome-report-generator-6.2.0.tgz",
-      "integrity": "sha512-Ghw8JhQFizF0Vjbtp9B0i//+BOkV5OWcQCPpbO0NGOoxV33o+gKDYU0Pr2pGxkIHnqZ+g5mYiXF7GMNgAcDpSg==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/mochawesome-report-generator/-/mochawesome-report-generator-6.3.2.tgz",
+      "integrity": "sha512-iB6iyOUMyMr8XOUYTNfrqYuZQLZka3K/Gr2GPc6CHPe7t2ZhxxfcoVkpMLOtyDKnWbY1zgu1/7VNRsigrvKnOQ==",
       "requires": {
         "chalk": "^4.1.2",
         "dateformat": "^4.5.1",
@@ -19937,7 +19661,6 @@
         "prop-types": "^15.7.2",
         "tcomb": "^3.2.17",
         "tcomb-validation": "^3.3.0",
-        "validator": "^13.6.0",
         "yargs": "^17.2.1"
       },
       "dependencies": {
@@ -22838,11 +22561,6 @@
       "requires": {
         "builtins": "^5.0.0"
       }
-    },
-    "validator": {
-      "version": "13.15.23",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.23.tgz",
-      "integrity": "sha512-4yoz1kEWqUjzi5zsPbAS/903QXSYp0UOtHsPpp7p9rHAw/W+dkInskAE386Fat3oKRROwO98d9ZB0G4cObgUyw=="
     },
     "verror": {
       "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "commander": "^10.0.1",
     "fs-extra": "^11.3.0",
-    "mochawesome": "^7.1.4",
+    "mochawesome": "^7.1.3",
     "mochawesome-report-generator": "^6.2.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -35,8 +35,7 @@
   "dependencies": {
     "commander": "^10.0.1",
     "fs-extra": "^11.3.0",
-    "mochawesome": "^7.1.3",
-    "mochawesome-merge": "^5.0.0",
+    "mochawesome": "^7.1.4",
     "mochawesome-report-generator": "^6.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- replace `mochawesome-merge` with an internal merge for the reporter's generated JSON files
- preserve `mochawesome` at `^7.1.3` and `mochawesome-report-generator` at `^6.2.0` to avoid unrelated report UI behavior changes
- remove the `mochawesome-merge -> glob` dependency chain from production dependencies
  - fixes the deprecated `glob@10.5.0` warning introduced by that dependency chain

## Verification
- `npm ci`
- `npm run test` (71 tests passing)
- `npm ls mochawesome-merge`
- `npm pack --dry-run`

